### PR TITLE
use GridCells.Adaptive()

### DIFF
--- a/shared/src/commonMain/kotlin/App.kt
+++ b/shared/src/commonMain/kotlin/App.kt
@@ -70,7 +70,7 @@ fun BirdsPage(viewModel: BirdsViewModel) {
                     onClick = {
                         viewModel.selectCategory(category)
                     },
-                    modifier = Modifier.aspectRatio(1.0f).fillMaxSize().weight(1.0f),
+                    modifier = Modifier.fillMaxWidth().weight(1.0f),
                     elevation = ButtonDefaults.elevation(
                         defaultElevation = 0.dp,
                         focusedElevation = 0.dp
@@ -83,7 +83,7 @@ fun BirdsPage(viewModel: BirdsViewModel) {
         }
         AnimatedVisibility(uiState.selectedImages.isNotEmpty()) {
             LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
+                columns = GridCells.Adaptive(150.dp),
                 horizontalArrangement = Arrangement.spacedBy(5.dp),
                 verticalArrangement = Arrangement.spacedBy(5.dp),
                 modifier = Modifier.fillMaxSize().padding(horizontal = 5.dp),


### PR DESCRIPTION
Not that important in context of what's being demonstrated in sample but just capturing in PR in case useful.  It's cool as well that `GridCells.Adaptive()` works across platforms (screenshot here is from iPhone simulator)

![Simulator Screenshot - iPhone 14 Pro - 2023-07-27 at 22 28 36](https://github.com/SebastianAigner/my-bird-app/assets/6302/118fc5d2-e725-48d2-8373-d1964c0b4d30)


btw branch name here is misleading as originally thought I'd have to use https://github.com/chrisbanes/material3-windowsizeclass-multiplatform

I also changed button height here so it looked ok in phone landscape mode but maybe better way to do that.